### PR TITLE
Optimizations and histogram statistics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/.idea
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "histogram"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
+
+[[package]]
 name = "indexmap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +114,7 @@ checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 name = "preprocessor"
 version = "0.1.0"
 dependencies = [
+ "histogram",
  "indexmap",
  "lazy_static",
  "lfu_cache",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,6 @@ lazy_static = { version = "1.4.0" }
 indexmap = {version = "1.9.2", features = ["serde-1"] }
 lru = { version = "0.8.1" }
 lfu_cache = { version = "1.2.2" }
+histogram = "*"
+
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,4 +1,3 @@
-use std::hash::Hash;
 use lru::LruCache;
 use std::num::NonZeroUsize;
 use lfu_cache::LfuCache;
@@ -49,10 +48,8 @@ impl CacheModel
             if let Some(_value) = self.lfu_cache.get(&key) {
                 return self.index_cache.get_index_of(&key)
             }
-        } else {
-            if let Some(_value) = self.lru_cache.get(&key) {
-                return self.index_cache.get_index_of(&key)
-            } 
+        } else if let Some(_value) = self.lru_cache.get(&key) {
+            return self.index_cache.get_index_of(&key)
         }
 
         None

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ fn decode(command: &mut load::StoreCommand, cache: &mut cache::CacheModel) {
 fn main() {
     let mut commands = load::read_from_file("queries.txt");
     let mut cache = cache::CacheModel::with(500, true);
-    let command_num = commands.len();
+    let command_num = commands.len() as u32;
     println!("find {} commands.", command_num);
 
     let now = Instant::now();
@@ -76,8 +76,7 @@ fn main() {
     }
 
     let elapsed = now.elapsed();
-    let preprocess_time = elapsed.as_micros() as u64;
-    let average_time = preprocess_time as f64 / command_num as f64;
-    println!("We handled {} commands in {} microsecs.", command_num, preprocess_time);
-    println!("On average, one command takes {:.2} microsecs.", average_time);
+    println!("We handled {} commands in {:?}.", command_num, elapsed);
+    println!("On average, one command takes {:?}.", elapsed/command_num);
+    // println!("On average, one command takes {:.2} microsecs.", average_time);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ fn encode(command: &mut load::StoreCommand, cache: &mut cache::CacheModel) {
     if let Some(index) = cache.get_index_of(cache_key.clone()) {
         // exists in cache
         // send index and parameters
-        let compressed = format!("1*|*{}*|*{}", index.to_string(), parameters);
+        let compressed = format!("1*|*{}*|*{}", index, parameters);
 
         command.sql = compressed;
     } else {
@@ -58,13 +58,13 @@ fn decode(command: &mut load::StoreCommand, cache: &mut cache::CacheModel) {
 }
 
 fn main() {
-    let mut commands = load::read_from_file("queries.txt");
+    let commands = load::read_from_file("queries.txt");
     let mut cache = cache::CacheModel::with(500, true);
     let command_num = commands.len() as u32;
     println!("find {} commands.", command_num);
 
     let now = Instant::now();
-    /// run with checks
+    // run with checks
     for command in commands.into_iter() {
         let mut raw_command = command.clone();
         encode(&mut raw_command, &mut cache);

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -24,8 +24,8 @@ pub fn split_query(query: &str) -> (String, String) {
             if bitmap[index] == 1 {
                 continue
             } else {
-                for i in index..index+mat.len() {
-                    bitmap[i] = 1;
+                for bitmap_entry in bitmap.iter_mut().skip(index).take(mat.len()) {
+                    *bitmap_entry = 1;
                 }
             }
 
@@ -56,11 +56,11 @@ pub fn merge_query(template: String, parameters: String) -> String {
     if parameters.is_empty() { return template; }
 
     let parameter_list = parameters
-        .split(",")
+        .split(',')
         .collect::<Vec<_>>();
     let num_parameters = parameter_list.len();
 
-    let parts = template.split("@").collect::<Vec<_>>();
+    let parts = template.split('@').collect::<Vec<_>>();
     if  parts.len() != num_parameters+1 {
         println!("Unmatched templates {} \n and parameters {}", template, parameters);
         return template;

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -1,31 +1,85 @@
 use regex::Regex;
 use lazy_static::lazy_static;
+use crate::{cache, load, preprocess};
+
+const RULES: [&str; 2] = [
+    r#"('\d+\\.*?')"#,                // hash values
+    //r#"'((')|(.*?([^\\])'))"#,        // string
+    //r#""((")|(.*?([^\\])"))"#,        // double-quoted string
+    r#"([^a-zA-Z'(,\*])\d+(\.\d+)?"#,   // integers(prevent us from capturing table name like "a1")
+];
+
+lazy_static! {
+    static ref REGEX_SETS: [Regex; 2] = [
+        Regex::new(RULES[0]).unwrap(),
+        Regex::new(RULES[1]).unwrap(),
+    ];
+}
+
+pub fn encode(command: &mut load::StoreCommand, cache: &mut cache::CacheModel) {
+    // split sql into template and parameters
+    let (template, parameters) = preprocess::split_query(&command.sql);
+    let cache_key: cache::CacheKey = template.clone();
+    let cache_value: cache::CacheValue = template.clone();
+
+    if let Some(index) = cache.get_index_of(cache_key.clone()) {
+        // exists in cache
+        // send index and parameters
+        let compressed = format!("1*|*{}*|*{}", index, parameters);
+        command.sql = compressed;
+    } else {
+        // send template and parameters
+        let uncompressed = format!("0*|*{}*|*{}", template, parameters);
+        command.sql = uncompressed;
+    }
+
+    // update cache for leader
+    cache.put(cache_key, cache_value);
+}
+
+pub fn decode(command: &mut load::StoreCommand, cache: &mut cache::CacheModel) {
+    let parts: Vec<&str> = command.sql.split("*|*").collect();
+    if parts.len() != 3 {
+        panic!("Unexpected query: {:?}", command.sql);
+    }
+
+    let (compressed, index_or_template, parameters) = (parts[0], parts[1].to_string(), parts[2].to_string());
+    let mut template = index_or_template.clone();
+
+    if compressed == "1" {
+        // compressed messsage
+        let index = index_or_template.parse::<usize>().unwrap();
+        if let Some((_key, value)) = cache.get_with_index(index) {
+            template = value.clone();
+        } else {
+            let index = index;
+            let sql = command.sql.clone();
+            let size = cache.len();
+
+            panic!("Query:{} is out of index: {}/{:?}", sql, index, size);
+        }
+    }
+
+    // update cache for followers
+    let cache_key: cache::CacheKey = template.clone();
+    let cache_value: cache::CacheValue = template.clone();
+    cache.put(cache_key, cache_value);
+    command.sql = preprocess::merge_query(template, parameters);
+}
 
 // Split a raw sql query into a template and parameters
 // A query template contains only the operations but no values
 // All parameters are connected as a string by comma
 pub fn split_query(query: &str) -> (String, String) {
-    lazy_static! {
-        static ref RULES: Vec<&'static str> = vec![
-            r#"('\d+\\.*?')"#,                // hash values
-            //r#"'((')|(.*?([^\\])'))"#,        // string
-            //r#""((")|(.*?([^\\])"))"#,        // double-quoted string
-            r#"([^a-zA-Z'(,\*])\d+(\.\d+)?"#,   // integers(prevent us from capturing table name like "a1")
-        ];
-        static ref REGEX_SETS: Vec<Regex> = RULES.iter()
-                    .map(|s| Regex::new(s).unwrap())
-                    .collect();
-    }
-
-    let mut bitmap = vec![0;query.len()];
-    let mut indice_pairs = Vec::new();
+    let mut bitmap: Vec<bool> = vec![false;query.len()];
+    let mut indice_pairs = Vec::with_capacity(50);
     for re in REGEX_SETS.iter() {
         for (index, mat) in query.match_indices(re) {
-            if bitmap[index] == 1 {
+            if bitmap[index] == true {
                 continue
             } else {
                 for bitmap_entry in bitmap.iter_mut().skip(index).take(mat.len()) {
-                    *bitmap_entry = 1;
+                    *bitmap_entry = true;
                 }
             }
 


### PR DESCRIPTION
I did some optimizations in the encoding and fixed `clippy` hints (please make sure to run `cargo clippy` moving forward) and managed to reduce the pre-processing by around 1.3 micro seconds on my machine.

Also changed the measurements to use `Histogram` to get more insights (p50, p95, min, max, etc.).