### PR TITLE
Remove unnecessary CacheValue and a bunch of clones(), formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /.idea
 .DS_Store
+*.iml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ lru = { version = "0.8.1" }
 lfu_cache = { version = "1.2.2" }
 histogram = "*"
 
-
+[profile.release]
+lto = true

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -53,12 +53,12 @@ impl CacheModel {
     }
 
     /// get index from cache
-    pub fn get_index_of(&mut self, key: &CacheKey) -> Option<usize> {
+    pub fn get_index_of(&self, key: &CacheKey) -> Option<usize> {
         self.index_cache.get_index_of(key)
     }
 
     /// get value from cache
-    pub fn get_with_index(&mut self, index: usize) -> Option<(&CacheKey, &PhantomData<u32>)> {
+    pub fn get_with_index(&self, index: usize) -> Option<(&CacheKey, &PhantomData<u32>)> {
         self.index_cache.get_index(index)
     }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -40,6 +40,18 @@ impl CacheModel {
         self.index_cache.insert(key, PhantomData);
     }
 
+    /// update the frequency or recency of the template.
+    pub fn update_cache(&mut self, key: &CacheKey) {
+        if self.use_lfu {
+            let _ = self
+                .lfu_cache
+                .get(key)
+                .expect("Tried to update frequency of cache item that doesn't exist.");
+        } else {
+            self.lru_cache.promote(key);
+        }
+    }
+
     /// get index from cache
     pub fn get_index_of(&mut self, key: &CacheKey) -> Option<usize> {
         self.index_cache.get_index_of(key)

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,22 +1,20 @@
-use lru::LruCache;
-use std::num::NonZeroUsize;
-use lfu_cache::LfuCache;
 use indexmap::IndexMap;
+use lfu_cache::LfuCache;
+use lru::LruCache;
+use std::marker::PhantomData;
+use std::num::NonZeroUsize;
 
 pub type CacheKey = String;
-pub type CacheValue = String;
 
 /// The cache we use in paxos
-pub struct CacheModel
-{
+pub struct CacheModel {
     use_lfu: bool,
-    lfu_cache: LfuCache<CacheKey, CacheValue>,
-    lru_cache: LruCache<CacheKey, CacheValue>,
-    index_cache: IndexMap<CacheKey, CacheValue>,
+    lfu_cache: LfuCache<CacheKey, PhantomData<u32>>,
+    lru_cache: LruCache<CacheKey, PhantomData<u32>>,
+    index_cache: IndexMap<CacheKey, PhantomData<u32>>,
 }
 
-impl CacheModel
-{
+impl CacheModel {
     /// create a new cache model
     pub fn with(capacity: usize, use_lfu: bool) -> Self {
         let lfu_cache_capacity = if use_lfu { capacity } else { 1 };
@@ -32,31 +30,23 @@ impl CacheModel
 
     /// save (key, value) pair into cache
     /// Optimization: The value could be skipped if it always equals to the key
-    pub fn put(&mut self, key: CacheKey, value: CacheValue) {
+    pub fn put(&mut self, key: CacheKey) {
         if self.use_lfu {
-            self.lfu_cache.insert(key.clone(), value.clone());
+            self.lfu_cache.insert(key.clone(), PhantomData);
         } else {
-            self.lru_cache.put(key.clone(), value.clone());
+            self.lru_cache.put(key.clone(), PhantomData);
         }
 
-        self.index_cache.insert(key, value);
+        self.index_cache.insert(key, PhantomData);
     }
 
     /// get index from cache
-    pub fn get_index_of(&mut self, key: CacheKey) -> Option<usize> {
-        if self.use_lfu {
-            if let Some(_value) = self.lfu_cache.get(&key) {
-                return self.index_cache.get_index_of(&key)
-            }
-        } else if let Some(_value) = self.lru_cache.get(&key) {
-            return self.index_cache.get_index_of(&key)
-        }
-
-        None
+    pub fn get_index_of(&mut self, key: &CacheKey) -> Option<usize> {
+        self.index_cache.get_index_of(key)
     }
 
     /// get value from cache
-    pub fn get_with_index(&mut self, index: usize) -> Option<(&CacheKey, &CacheValue)> {
+    pub fn get_with_index(&mut self, index: usize) -> Option<(&CacheKey, &PhantomData<u32>)> {
         self.index_cache.get_index(index)
     }
 

--- a/src/load.rs
+++ b/src/load.rs
@@ -1,4 +1,3 @@
-
 use std::fs::File;
 use std::io::{self, BufRead};
 use std::path::Path;
@@ -30,7 +29,9 @@ pub fn read_from_file(filepath: &str) -> Vec<StoreCommand> {
 }
 
 fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>>
-where P: AsRef<Path>, {
+where
+    P: AsRef<Path>,
+{
     let file = File::open(filename)?;
     Ok(io::BufReader::new(file).lines())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
-mod load;
 mod cache;
+mod load;
 mod preprocess;
 
-use std::time::Instant;
-use histogram::Histogram;
 use crate::preprocess::{decode, encode};
+use histogram::Histogram;
+use std::time::Instant;
 
 fn main() {
     let commands = load::read_from_file("queries.txt");
@@ -15,7 +15,6 @@ fn main() {
     let mut encode_histo = Histogram::new();
     let mut decode_histo = Histogram::new();
     let mut query_len_histo = Histogram::new();
-
 
     // run with checks
     for command in &commands[0..] {
@@ -35,28 +34,31 @@ fn main() {
         query_len_histo.increment(command.sql.len() as u64).unwrap();
     }
     println!("Number of commands: {}", num_commands);
-    println!("Encoding (ns): Avg: {}, p50: {}, p95: {}, Min: {}, Max: {}, StdDev: {}",
-             encode_histo.mean().unwrap(),
-             encode_histo.percentile(50f64).unwrap(),
-             encode_histo.percentile(95f64).unwrap(),
-             encode_histo.minimum().unwrap(),
-             encode_histo.maximum().unwrap(),
-             encode_histo.stddev().unwrap(),
+    println!(
+        "Encoding (ns): Avg: {}, p50: {}, p95: {}, Min: {}, Max: {}, StdDev: {}",
+        encode_histo.mean().unwrap(),
+        encode_histo.percentile(50f64).unwrap(),
+        encode_histo.percentile(95f64).unwrap(),
+        encode_histo.minimum().unwrap(),
+        encode_histo.maximum().unwrap(),
+        encode_histo.stddev().unwrap(),
     );
-    println!("Decoding (ns): Avg: {}, p50: {}, p95: {},Min: {}, Max: {}, StdDev: {}",
-             decode_histo.mean().unwrap(),
-             decode_histo.percentile(50f64).unwrap(),
-             decode_histo.percentile(95f64).unwrap(),
-             decode_histo.minimum().unwrap(),
-             decode_histo.maximum().unwrap(),
-             decode_histo.stddev().unwrap(),
+    println!(
+        "Decoding (ns): Avg: {}, p50: {}, p95: {},Min: {}, Max: {}, StdDev: {}",
+        decode_histo.mean().unwrap(),
+        decode_histo.percentile(50f64).unwrap(),
+        decode_histo.percentile(95f64).unwrap(),
+        decode_histo.minimum().unwrap(),
+        decode_histo.maximum().unwrap(),
+        decode_histo.stddev().unwrap(),
     );
-    println!("Query length: Avg: {}, p50: {}, p95: {}, Min: {}, Max: {}, StdDev: {}",
-             query_len_histo.mean().unwrap(),
-             query_len_histo.percentile(50f64).unwrap(),
-             query_len_histo.percentile(95f64).unwrap(),
-             query_len_histo.minimum().unwrap(),
-             query_len_histo.maximum().unwrap(),
-             query_len_histo.stddev().unwrap(),
+    println!(
+        "Query length: Avg: {}, p50: {}, p95: {}, Min: {}, Max: {}, StdDev: {}",
+        query_len_histo.mean().unwrap(),
+        query_len_histo.percentile(50f64).unwrap(),
+        query_len_histo.percentile(95f64).unwrap(),
+        query_len_histo.minimum().unwrap(),
+        query_len_histo.maximum().unwrap(),
+        query_len_histo.stddev().unwrap(),
     );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ fn main() {
         encode_histo.stddev().unwrap(),
     );
     println!(
-        "Decoding (ns): Avg: {}, p50: {}, p95: {},Min: {}, Max: {}, StdDev: {}",
+        "Decoding (ns): Avg: {}, p50: {}, p95: {}, Min: {}, Max: {}, StdDev: {}",
         decode_histo.mean().unwrap(),
         decode_histo.percentile(50f64).unwrap(),
         decode_histo.percentile(95f64).unwrap(),

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -1,28 +1,25 @@
-use regex::Regex;
-use lazy_static::lazy_static;
 use crate::{cache, load, preprocess};
+use lazy_static::lazy_static;
+use regex::Regex;
 
 const RULES: [&str; 2] = [
-    r#"('\d+\\.*?')"#,                // hash values
+    r#"('\d+\\.*?')"#, // hash values
     //r#"'((')|(.*?([^\\])'))"#,        // string
     //r#""((")|(.*?([^\\])"))"#,        // double-quoted string
-    r#"([^a-zA-Z'(,\*])\d+(\.\d+)?"#,   // integers(prevent us from capturing table name like "a1")
+    r#"([^a-zA-Z'(,\*])\d+(\.\d+)?"#, // integers(prevent us from capturing table name like "a1")
 ];
 
 lazy_static! {
-    static ref REGEX_SETS: [Regex; 2] = [
-        Regex::new(RULES[0]).unwrap(),
-        Regex::new(RULES[1]).unwrap(),
-    ];
+    static ref REGEX_SETS: [Regex; 2] =
+        [Regex::new(RULES[0]).unwrap(), Regex::new(RULES[1]).unwrap(),];
 }
 
 pub fn encode(command: &mut load::StoreCommand, cache: &mut cache::CacheModel) {
     // split sql into template and parameters
     let (template, parameters) = preprocess::split_query(&command.sql);
     let cache_key: cache::CacheKey = template.clone();
-    let cache_value: cache::CacheValue = template.clone();
 
-    if let Some(index) = cache.get_index_of(cache_key.clone()) {
+    if let Some(index) = cache.get_index_of(&cache_key) {
         // exists in cache
         // send index and parameters
         let compressed = format!("1*|*{}*|*{}", index, parameters);
@@ -34,7 +31,7 @@ pub fn encode(command: &mut load::StoreCommand, cache: &mut cache::CacheModel) {
     }
 
     // update cache for leader
-    cache.put(cache_key, cache_value);
+    cache.put(cache_key);
 }
 
 pub fn decode(command: &mut load::StoreCommand, cache: &mut cache::CacheModel) {
@@ -43,14 +40,15 @@ pub fn decode(command: &mut load::StoreCommand, cache: &mut cache::CacheModel) {
         panic!("Unexpected query: {:?}", command.sql);
     }
 
-    let (compressed, index_or_template, parameters) = (parts[0], parts[1].to_string(), parts[2].to_string());
+    let (compressed, index_or_template, parameters) =
+        (parts[0], parts[1].to_string(), parts[2].to_string());
     let mut template = index_or_template.clone();
 
     if compressed == "1" {
         // compressed messsage
         let index = index_or_template.parse::<usize>().unwrap();
-        if let Some((_key, value)) = cache.get_with_index(index) {
-            template = value.clone();
+        if let Some((key, _value)) = cache.get_with_index(index) {
+            template = key.clone();
         } else {
             let index = index;
             let sql = command.sql.clone();
@@ -62,8 +60,7 @@ pub fn decode(command: &mut load::StoreCommand, cache: &mut cache::CacheModel) {
 
     // update cache for followers
     let cache_key: cache::CacheKey = template.clone();
-    let cache_value: cache::CacheValue = template.clone();
-    cache.put(cache_key, cache_value);
+    cache.put(cache_key);
     command.sql = preprocess::merge_query(template, parameters);
 }
 
@@ -71,12 +68,12 @@ pub fn decode(command: &mut load::StoreCommand, cache: &mut cache::CacheModel) {
 // A query template contains only the operations but no values
 // All parameters are connected as a string by comma
 pub fn split_query(query: &str) -> (String, String) {
-    let mut bitmap: Vec<bool> = vec![false;query.len()];
+    let mut bitmap: Vec<bool> = vec![false; query.len()];
     let mut indice_pairs = Vec::with_capacity(50);
     for re in REGEX_SETS.iter() {
         for (index, mat) in query.match_indices(re) {
-            if bitmap[index] == true {
-                continue
+            if bitmap[index] {
+                continue;
             } else {
                 for bitmap_entry in bitmap.iter_mut().skip(index).take(mat.len()) {
                     *bitmap_entry = true;
@@ -84,7 +81,7 @@ pub fn split_query(query: &str) -> (String, String) {
             }
 
             indice_pairs.push((index, mat));
-        } 
+        }
     }
     let mut template = query.to_string();
     for re in REGEX_SETS.iter() {
@@ -95,10 +92,11 @@ pub fn split_query(query: &str) -> (String, String) {
     // println!("indice_pairs: {:?}", indice_pairs);
 
     // println!("template: {:?}", template);
-    let parameters = indice_pairs.iter()
-                        .map(|p| p.1)
-                        .collect::<Vec<_>>()
-                        .join(",");
+    let parameters = indice_pairs
+        .iter()
+        .map(|p| p.1)
+        .collect::<Vec<_>>()
+        .join(",");
     // println!("parameters: {:?}", parameters);
 
     (template, parameters)
@@ -107,16 +105,19 @@ pub fn split_query(query: &str) -> (String, String) {
 // Merge template string with parameters
 // There should be the exact number of parameters to fill in
 pub fn merge_query(template: String, parameters: String) -> String {
-    if parameters.is_empty() { return template; }
+    if parameters.is_empty() {
+        return template;
+    }
 
-    let parameter_list = parameters
-        .split(',')
-        .collect::<Vec<_>>();
+    let parameter_list = parameters.split(',').collect::<Vec<_>>();
     let num_parameters = parameter_list.len();
 
     let parts = template.split('@').collect::<Vec<_>>();
-    if  parts.len() != num_parameters+1 {
-        println!("Unmatched templates {} \n and parameters {}", template, parameters);
+    if parts.len() != num_parameters + 1 {
+        println!(
+            "Unmatched templates {} \n and parameters {}",
+            template, parameters
+        );
         return template;
     }
 


### PR DESCRIPTION
The cache was storing redundant data and some calls were using `CacheKey` instead of `&CacheKey` which required a bunch of unnecessary `clone()` calls. 

Also fixed a bug when updating the frequency or recency of the cache. Using `put()` will reset the frequency in LFU and not update the recency in LRU. Furthermore, `put()` is only necessary when there is a cache miss and a new template should be added. 

These changes resulted in improvements of ~20% for encoding and ~50% for decoding.