### PR TITLE
Use separate decoder in benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.idea
 .DS_Store
 *.iml
+*.zip
+raw_queries.txt

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,12 +1,5 @@
-use indexmap::IndexMap;
-use lecar::controller::Controller;
-use lfu_cache::LfuCache;
-use lru::LruCache;
-use std::marker::PhantomData;
-use std::num::NonZeroUsize;
+use std::fmt::Debug;
 use strum_macros::EnumIter;
-
-pub type CacheKey = String;
 
 #[derive(Debug, Eq, PartialEq, EnumIter)]
 pub enum CacheType {
@@ -15,97 +8,14 @@ pub enum CacheType {
     LECAR,
 }
 
-/// The cache we use in paxos
-pub struct CacheModel {
-    cache_type: CacheType,
-    lfu_cache: LfuCache<CacheKey, PhantomData<u32>>,
-    lru_cache: LruCache<CacheKey, PhantomData<u32>>,
-    lecar_cache: Controller,
-    index_cache: IndexMap<CacheKey, PhantomData<u32>>,
-}
+// pub trait CacheItem: Clone + Debug + Hash + Eq {}
 
-impl CacheModel {
-    /// create a new cache model
-    pub fn with(capacity: usize, cache_type: CacheType) -> Self {
-        CacheModel {
-            cache_type,
-            lfu_cache: LfuCache::with_capacity(capacity),
-            lru_cache: LruCache::new(NonZeroUsize::new(capacity).unwrap()),
-            lecar_cache: Controller::new(capacity, capacity, capacity),
-            index_cache: IndexMap::with_capacity(capacity),
-        }
-    }
+pub trait UniCache<T> {
+    fn new(capacity: usize) -> Self;
 
-    /// save (key, value) pair into cache
-    /// Optimization: The value could be skipped if it always equals to the key
-    pub fn put(&mut self, key: CacheKey) {
-        match self.cache_type {
-            CacheType::LFU => {
-                self.lfu_cache.insert(key.clone(), PhantomData);
-            }
-            CacheType::LRU => {
-                self.lru_cache.put(key.clone(), PhantomData);
-            }
-            CacheType::LECAR => {
-                self.lecar_cache.insert(&key, 0);
-            }
-        }
+    fn put(&mut self, item: T);
 
-        self.index_cache.insert(key, PhantomData);
-    }
+    fn get_encoded_index(&mut self, item: &T) -> Option<usize>;
 
-    /// update the frequency or recency of the template.
-    pub fn update_cache(&mut self, key: &CacheKey) {
-        match self.cache_type {
-            CacheType::LFU => {
-                self.lfu_cache.get(key).expect(
-                    format!(
-                        "Tried to update frequency of cache item that doesn't exist: {:?}",
-                        key
-                    )
-                    .as_str(),
-                );
-            }
-            CacheType::LRU => {
-                self.lru_cache.promote(key);
-            }
-            CacheType::LECAR => {
-                self.lecar_cache.get(key).expect(
-                    format!(
-                        "Tried to update frequency of cache item that doesn't exist: {:?}",
-                        key
-                    )
-                    .as_str(),
-                );
-            }
-        }
-    }
-
-    /// get index from cache
-    pub fn get_index_of(&mut self, key: &CacheKey) -> Option<usize> {
-        let exists = match self.cache_type {
-            CacheType::LFU => self.lfu_cache.get(key).is_some(),
-            CacheType::LRU => self.lru_cache.get(key).is_some(),
-            CacheType::LECAR => self.lecar_cache.get(key).is_some(),
-        };
-        if exists {
-            self.index_cache.get_index_of(key)
-        } else {
-            None
-        }
-    }
-
-    /// get value from cache
-    pub fn get_with_index(&self, index: usize) -> Option<(&CacheKey, &PhantomData<u32>)> {
-        self.index_cache.get_index(index)
-    }
-
-    /// return cache length
-    pub fn len(&self) -> usize {
-        match self.cache_type {
-            CacheType::LFU => self.lfu_cache.len(),
-            CacheType::LRU => self.lru_cache.len(),
-            CacheType::LECAR => self.lecar_cache.len().0,
-        }
-    }
+    fn get_with_encoded_index(&mut self, index: usize) -> T;
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -8,7 +8,7 @@ use strum_macros::EnumIter;
 
 pub type CacheKey = String;
 
-#[derive(Debug, Eq, PartialEq, EnumIter)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, EnumIter)]
 pub enum CacheType {
     LFU,
     LRU,

--- a/src/lecar_cache.rs
+++ b/src/lecar_cache.rs
@@ -1,0 +1,26 @@
+use crate::cache::UniCache;
+use lecar::controller::Controller;
+
+pub struct LecarUniCache {
+    lecar_cache: Controller,
+}
+
+impl UniCache<String> for LecarUniCache {
+    fn new(capacity: usize) -> Self {
+        Self {
+            lecar_cache: Controller::new(capacity, capacity, capacity),
+        }
+    }
+
+    fn put(&mut self, item: String) {
+        self.lecar_cache.insert(&item, 0);
+    }
+
+    fn get_encoded_index(&mut self, item: &String) -> Option<usize> {
+        self.lecar_cache.get_index_of(item)
+    }
+
+    fn get_with_encoded_index(&mut self, index: usize) -> String {
+        self.lecar_cache.get_index(index).unwrap().to_string()
+    }
+}

--- a/src/lfu_cache.rs
+++ b/src/lfu_cache.rs
@@ -1,0 +1,46 @@
+use crate::cache::UniCache;
+use indexmap::IndexMap;
+use lfu_cache::LfuCache;
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::marker::PhantomData;
+
+pub struct LfuUniCache<T: Clone + Debug + Hash + Eq> {
+    lfu_cache: LfuCache<T, PhantomData<bool>>,
+    index_cache: IndexMap<T, PhantomData<bool>>,
+}
+
+impl<T: Clone + Debug + Hash + Eq> UniCache<T> for LfuUniCache<T> {
+    fn new(capacity: usize) -> Self {
+        Self {
+            lfu_cache: LfuCache::with_capacity(capacity),
+            index_cache: IndexMap::with_capacity(capacity),
+        }
+    }
+
+    fn put(&mut self, item: T) {
+        let _maybe_evicted = self.lfu_cache.insert(item.clone(), PhantomData);
+        // TODO remove maybe_evicted item from index_cache
+        self.index_cache.insert(item, PhantomData);
+    }
+
+    fn get_encoded_index(&mut self, item: &T) -> Option<usize> {
+        if self.lfu_cache.get(item).is_some() {
+            self.index_cache.get_index_of(item)
+        } else {
+            None
+        }
+    }
+
+    fn get_with_encoded_index(&mut self, index: usize) -> T {
+        let item = self.index_cache.get_index(index).unwrap().0.clone();
+        self.lfu_cache.get(&item).expect(
+            format!(
+                "Tried to update frequency of cache item that doesn't exist: {:?}",
+                &item
+            )
+            .as_str(),
+        );
+        item
+    }
+}

--- a/src/lfu_cache.rs
+++ b/src/lfu_cache.rs
@@ -34,13 +34,12 @@ impl<T: Clone + Debug + Hash + Eq> UniCache<T> for LfuUniCache<T> {
 
     fn get_with_encoded_index(&mut self, index: usize) -> T {
         let item = self.index_cache.get_index(index).unwrap().0.clone();
-        self.lfu_cache.get(&item).expect(
-            format!(
+        self.lfu_cache.get(&item).unwrap_or_else(|| {
+            panic!(
                 "Tried to update frequency of cache item that doesn't exist: {:?}",
                 &item
             )
-            .as_str(),
-        );
+        });
         item
     }
 }

--- a/src/load.rs
+++ b/src/load.rs
@@ -1,16 +1,18 @@
+/*
 use std::fs::File;
 use std::io::{self, BufRead};
 use std::path::Path;
+*/
 
 #[derive(Debug, Clone)]
 pub struct StoreCommand {
-    pub _id: usize,
+    pub id: usize,
     pub sql: String,
 }
-
+/*
 impl StoreCommand {
     pub fn new(id: usize, sql: String) -> StoreCommand {
-        StoreCommand { _id: id, sql }
+        StoreCommand { id: id, sql }
     }
 }
 
@@ -35,3 +37,4 @@ where
     let file = File::open(filename)?;
     Ok(io::BufReader::new(file).lines())
 }
+*/

--- a/src/lru_cache.rs
+++ b/src/lru_cache.rs
@@ -1,0 +1,43 @@
+use crate::cache::UniCache;
+use indexmap::IndexMap;
+use lru::LruCache;
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::marker::PhantomData;
+use std::num::NonZeroUsize;
+
+pub struct LruUniCache<T: Clone + Debug + Hash + Eq> {
+    lru_cache: LruCache<T, PhantomData<bool>>,
+    index_cache: IndexMap<T, PhantomData<bool>>,
+}
+
+impl<T: Clone + Debug + Hash + Eq> UniCache<T> for LruUniCache<T> {
+    fn new(capacity: usize) -> Self {
+        Self {
+            lru_cache: LruCache::new(NonZeroUsize::new(capacity).unwrap()),
+            index_cache: IndexMap::with_capacity(capacity),
+        }
+    }
+
+    fn put(&mut self, item: T) {
+        let maybe_evicted = self.lru_cache.push(item.clone(), PhantomData);
+        if let Some((evicted, _)) = maybe_evicted {
+            let _ = self.index_cache.remove(&evicted);
+        }
+        self.index_cache.insert(item, PhantomData);
+    }
+
+    fn get_encoded_index(&mut self, item: &T) -> Option<usize> {
+        if self.lru_cache.get(item).is_some() {
+            self.index_cache.get_index_of(item)
+        } else {
+            None
+        }
+    }
+
+    fn get_with_encoded_index(&mut self, index: usize) -> T {
+        let item = self.index_cache.get_index(index).unwrap().0.clone();
+        self.lru_cache.promote(&item);
+        item
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,13 @@ fn main() {
     let mut query_len_histo = Histogram::new();
 
     let mut lfu_cache = LfuUniCache::new(CACHE_CAPACITY);
+    let mut lfu_decoder = LfuUniCache::new(CACHE_CAPACITY);
+
     let mut lru_cache = LruUniCache::new(CACHE_CAPACITY);
+    let mut lru_decoder = LruUniCache::new(CACHE_CAPACITY);
+
     let mut lecar_cache = LecarUniCache::new(CACHE_CAPACITY);
+    let mut lecar_decoder = LecarUniCache::new(CACHE_CAPACITY);
 
     let mut lfu_res = Results::new(CacheType::LFU);
     let mut lru_res = Results::new(CacheType::LRU);
@@ -53,7 +58,7 @@ fn main() {
                     let start = Instant::now();
                     let (hit, compression_rate) = encode(&mut raw_command, &mut lfu_cache);
                     let encode_end = Instant::now();
-                    decode(&mut raw_command, &mut lfu_cache);
+                    decode(&mut raw_command, &mut lfu_decoder);
                     let end = Instant::now();
                     lfu_res.update(start, encode_end, end, hit, compression_rate);
                 }
@@ -61,7 +66,7 @@ fn main() {
                     let start = Instant::now();
                     let (hit, compression_rate) = encode(&mut raw_command, &mut lru_cache);
                     let encode_end = Instant::now();
-                    decode(&mut raw_command, &mut lru_cache);
+                    decode(&mut raw_command, &mut lru_decoder);
                     let end = Instant::now();
                     lru_res.update(start, encode_end, end, hit, compression_rate);
                 }
@@ -69,7 +74,7 @@ fn main() {
                     let start = Instant::now();
                     let (hit, compression_rate) = encode(&mut raw_command, &mut lecar_cache);
                     let encode_end = Instant::now();
-                    decode(&mut raw_command, &mut lecar_cache);
+                    decode(&mut raw_command, &mut lecar_decoder);
                     let end = Instant::now();
                     lecar_res.update(start, encode_end, end, hit, compression_rate);
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use strum::IntoEnumIterator;
 type CacheKey = String;
 const CACHE_CAPACITY: usize = 500;
 const NUM_QUERIES: i64 = -1; // -1 to run the whole benchmark
+const FILE: &str = "queries-sample.txt";   // change this to run sample or full dataset.
 
 fn main() {
     let total_start = Instant::now();
@@ -35,7 +36,7 @@ fn main() {
     let mut lru_res = Results::new(CacheType::LRU);
     let mut lecar_res = Results::new(CacheType::LECAR);
 
-    let file = File::open("raw_queries.txt").unwrap();
+    let file = File::open(FILE).unwrap();
     let reader = BufReader::new(file);
     for (idx, line) in reader.lines().enumerate() {
         if idx as i64 == NUM_QUERIES {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ fn main() {
         println!("Measuring cache type: {:?}", cache_type);
 
         let mut cache = cache::CacheModel::with(500, cache_type);
+        let mut decode_cache = cache::CacheModel::with(500, cache_type);
         let mut encode_histo = Histogram::new();
         let mut decode_histo = Histogram::new();
         let mut query_len_histo = Histogram::new();
@@ -28,7 +29,7 @@ fn main() {
             let start = Instant::now();
             let (hit, compression_rate) = encode(&mut raw_command, &mut cache);
             let encode_end = Instant::now();
-            decode(&mut raw_command, &mut cache);
+            decode(&mut raw_command, &mut decode_cache);
             let decode_end = Instant::now();
 
             assert_eq!(raw_command.sql, command.sql);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,83 @@
+use crate::CacheType;
+use histogram::Histogram;
+use std::fmt;
+use std::fmt::Formatter;
+use std::time::Instant;
+
+pub(crate) struct Results {
+    cache_type: CacheType,
+    encode_histo: Histogram,
+    decode_histo: Histogram,
+    compression_histo: Histogram,
+    hit_count: usize,
+    total: usize,
+}
+
+impl Results {
+    pub(crate) fn new(cache_type: CacheType) -> Self {
+        Self {
+            cache_type,
+            encode_histo: Default::default(),
+            decode_histo: Default::default(),
+            compression_histo: Default::default(),
+            hit_count: 0,
+            total: 0,
+        }
+    }
+
+    pub(crate) fn update(
+        &mut self,
+        start: Instant,
+        encode_end: Instant,
+        end: Instant,
+        cache_hit: bool,
+        compression_ratio: usize,
+    ) {
+        let encode_time = encode_end.duration_since(start).as_nanos() as u64;
+        let decode_time = end.duration_since(encode_end).as_nanos() as u64;
+        self.encode_histo.increment(encode_time).unwrap();
+        self.decode_histo.increment(decode_time).unwrap();
+        self.compression_histo
+            .increment(compression_ratio as u64)
+            .unwrap();
+        self.total += 1;
+        if cache_hit {
+            self.hit_count += 1;
+        }
+    }
+}
+
+impl fmt::Display for Results {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let hit_rate = self.hit_count as f32 / self.total as f32;
+        write!(
+            f,
+            "--------------------------------
+            \nCache type: {:?}\n\
+            Encoding (ns): Avg: {}, p50: {}, p95: {}, Min: {}, Max: {}, StdDev: {}\n\
+            Decoding (ns): Avg: {}, p50: {}, p95: {}, Min: {}, Max: {}, StdDev: {}\n\
+            Compression Rate (%): Avg: {}, p50: {}, p95: {}, Min: {}, Max: {}, StdDev: {}\n\
+            Hit rate: {}\n",
+            self.cache_type,
+            self.encode_histo.mean().unwrap(),
+            self.encode_histo.percentile(50f64).unwrap(),
+            self.encode_histo.percentile(95f64).unwrap(),
+            self.encode_histo.minimum().unwrap(),
+            self.encode_histo.maximum().unwrap(),
+            self.encode_histo.stddev().unwrap(),
+            self.decode_histo.mean().unwrap(),
+            self.decode_histo.percentile(50f64).unwrap(),
+            self.decode_histo.percentile(95f64).unwrap(),
+            self.decode_histo.minimum().unwrap(),
+            self.decode_histo.maximum().unwrap(),
+            self.decode_histo.stddev().unwrap(),
+            self.compression_histo.mean().unwrap(),
+            self.compression_histo.percentile(50f64).unwrap(),
+            self.compression_histo.percentile(95f64).unwrap(),
+            self.compression_histo.minimum().unwrap(),
+            self.compression_histo.maximum().unwrap(),
+            self.compression_histo.stddev().unwrap(),
+            hit_rate,
+        )
+    }
+}


### PR DESCRIPTION
Some major changes including:

1. Currently the benchmark is using the same cache for encoding and decoding. I added a new cache to only do decoding as that is more realistic.
2. Created a trait `UniCache<T>` which defines the interface for the cache.
3. Separated the different eviction policies into their own structs: `LfuCache, LruCache, LecarCache`
4. The benchmark can now run the full dataset by changing the file path.
5. Changed the marker for parameters in the SQL template from `@` to `#` because some queries in the full dataset used `@`.